### PR TITLE
Turn order priority fix

### DIFF
--- a/TurnBasedBattleSystem/BattleManager.cs
+++ b/TurnBasedBattleSystem/BattleManager.cs
@@ -86,7 +86,7 @@ public static class BattleManager
 			CurrentEnemyActions.Add(EnemyAi.DoAction(enemy));
 	}
 
-	private static int ActionSort(IBattleAction a, IBattleAction b) => a.Priority - b.Priority;
+	private static int ActionSort(IBattleAction a, IBattleAction b) => b.Priority - a.Priority;
 
 	private static void Resolve(IBattleAction action)
 	{


### PR DESCRIPTION
This PR fixes an issue where faster units moved last in the turn priority order.

Now they should move first as intended.